### PR TITLE
Bugfix: show exception as request parameter

### DIFF
--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -48,14 +48,20 @@ class ExceptionController
      * the exception page (when true). If it is not present, the "debug" value passed into the constructor will
      * be used.
      *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param \Symfony\Component\Debug\Exception\FlattenException $exception
+     * @param \Symfony\Component\HttpKernel\Log\DebugLoggerInterface|null $logger
+     *
      * @return Response
      *
-     * @throws \InvalidArgumentException When the exception template does not exist
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
      */
     public function showAction(Request $request, FlattenException $exception, DebugLoggerInterface $logger = null)
     {
         $currentContent = $this->getAndCleanOutputBuffering($request->headers->get('X-Php-Ob-Level', -1));
-        $showException = $request->attributes->get('showException', $this->debug); // As opposed to an additional parameter, this maintains BC
+        $showException = $request->query->getBoolean('showException', $this->debug); // As opposed to an additional parameter, this maintains BC
 
         $code = $exception->getStatusCode();
 

--- a/Controller/PreviewErrorController.php
+++ b/Controller/PreviewErrorController.php
@@ -43,12 +43,13 @@ class PreviewErrorController
          * the additional "showException" flag.
          */
 
+        $request->query->set('showException', false);
+
         $subRequest = $request->duplicate(null, null, [
             '_controller' => $this->controller,
             'exception' => $exception,
             'logger' => null,
             'format' => $request->getRequestFormat(),
-            'showException' => false,
         ]);
 
         return $this->kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);

--- a/Controller/PreviewErrorController.php
+++ b/Controller/PreviewErrorController.php
@@ -43,14 +43,14 @@ class PreviewErrorController
          * the additional "showException" flag.
          */
 
-        $request->query->set('showException', false);
-
         $subRequest = $request->duplicate(null, null, [
             '_controller' => $this->controller,
             'exception' => $exception,
             'logger' => null,
             'format' => $request->getRequestFormat(),
         ]);
+
+        $subRequest->query->set('showException', false);
 
         return $this->kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
     }

--- a/Tests/Controller/ExceptionControllerTest.php
+++ b/Tests/Controller/ExceptionControllerTest.php
@@ -25,7 +25,7 @@ class ExceptionControllerTest extends TestCase
         $twig = $this->createTwigEnv(['@Twig/Exception/error404.html.twig' => '<html>not found</html>']);
 
         $request = $this->createRequest('html');
-        $request->attributes->set('showException', false);
+        $request->query->set('showException', false);
         $exception = FlattenException::create(new \Exception(), 404);
         $controller = new ExceptionController($twig, /* "showException" defaults to --> */ true);
 
@@ -53,7 +53,7 @@ class ExceptionControllerTest extends TestCase
         $twig = $this->createTwigEnv(['@Twig/Exception/exception_full.html.twig' => '<html></html>']);
 
         $request = $this->createRequest('txt');
-        $request->attributes->set('showException', true);
+        $request->query->set('showException', true);
         $exception = FlattenException::create(new \Exception());
         $controller = new ExceptionController($twig, false);
 

--- a/Tests/Controller/PreviewErrorControllerTest.php
+++ b/Tests/Controller/PreviewErrorControllerTest.php
@@ -23,10 +23,12 @@ class PreviewErrorControllerTest extends TestCase
     public function testForwardRequestToConfiguredController()
     {
         $request = Request::create('whatever');
+        $request->query->set('showException', true);
         $response = new Response('');
         $code = 123;
         $logicalControllerName = 'foo:bar:baz';
 
+        /** @var HttpKernelInterface|\PHPUnit\Framework\MockObject\MockObject $kernel */
         $kernel = $this->getMockBuilder('\Symfony\Component\HttpKernel\HttpKernelInterface')->getMock();
         $kernel
             ->expects($this->once())
@@ -38,7 +40,7 @@ class PreviewErrorControllerTest extends TestCase
                     $exception = $request->attributes->get('exception');
                     $this->assertInstanceOf(FlattenException::class, $exception);
                     $this->assertEquals($code, $exception->getStatusCode());
-                    $this->assertFalse($request->attributes->get('showException'));
+                    $this->assertFalse($request->query->get('showException'));
 
                     return true;
                 }),


### PR DESCRIPTION
The original implementation by @mpdude contained an error in `PreviewErrorController`, where _showException_ was set as a request attribute instead of a query parameter.

This was later disimproved by @fabpot by changing it from a request parameter to an attribute in `ExceptionController:showAction` as well, which made things more consistent, but also more unusable.

The phpdoc of `showAction()` states the original use case, which is also the only one I can think of that makes sense: using _showException_ as a request parameter. This commit restores the originally intended behavior and changes/fixes the tests accordingly.